### PR TITLE
next vegan release drops scores from summary.cca: use scores()

### DIFF
--- a/R/b_analyse.R
+++ b/R/b_analyse.R
@@ -1351,7 +1351,8 @@ RDA_plot <- function(phy.rda, Group, metadata = NULL, Group2 = NULL, env_rate = 
       stop("can be used only with constrained ordination")
     }
     # 提取样方和环境因子排序坐标，前两轴，I 型标尺
-    rda.scaling1 <- summary(phy.rda, scaling = scale)
+    rda.scaling1 <- vegan::scores(phy.rda, scaling = scale,
+                                  display=c("sites", "species", "bp"))
     rda.site <- data.frame(rda.scaling1$sites)[1:2]
     rda.site$sample <- rownames(rda.site)
     rda.env <- data.frame(rda.scaling1$biplot)[1:2]


### PR DESCRIPTION
Further discussion in vegan issue #203 in github.

pctax will fail CRAN checks after forthcoming vegan release. We dropped scores from `summary.cca` to gain more compact and human-readable information. However, `scores.cca` function will provide the dropped information.